### PR TITLE
fix: Trust user installed SSL certs

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".ShioriApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/presentation/src/main/res/xml/network_security_config.xml
+++ b/presentation/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system" />
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
This PR adds a network config that will allow the app to trust user installed certs that some of the Shiori users tend to use while running on local networks.

This should resolve the issue #43. 