### PR TITLE
Guard the external link launch in the reader view

### DIFF
--- a/presentation/src/main/java/com/desarrollodroide/pagekeeper/ui/readablecontent/ReadableContentScreen.kt
+++ b/presentation/src/main/java/com/desarrollodroide/pagekeeper/ui/readablecontent/ReadableContentScreen.kt
@@ -1,6 +1,8 @@
 package com.desarrollodroide.pagekeeper.ui.readablecontent
 
 import android.content.Intent
+import android.content.ActivityNotFoundException
+import android.widget.Toast
 import android.os.Build
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -110,7 +112,11 @@ fun ReadableContentScreen(
                                         override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
                                             request?.url?.let { url ->
                                                 val intent = Intent(Intent.ACTION_VIEW, url)
-                                                context.startActivity(intent)
+                                                try {
+                                                    context.startActivity(intent)
+                                                } catch (e: ActivityNotFoundException) {
+                                                    Toast.makeText(context, "No app found to open this link", Toast.LENGTH_SHORT).show()
+                                                }
                                                 return true
                                             }
                                             return false


### PR DESCRIPTION
This wraps the external link launch in the reader view so the app no longer crashes when there is no app available to open the link.

Before, the link was passed to `startActivity` directly, which throws `ActivityNotFoundException` on a device with no handler. With this change the link still opens when a handler exists, and otherwise the exception is caught and a short message is shown.

Closes #62.